### PR TITLE
make access control of routes/states more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,13 +236,13 @@ $stateProvider.state('home', { data: { public: true } });
 
 The `login` route/state, the `verify_email` route/state, and the `set_password` route/state are considered public by default.
 
-If the user is not signed in and accesses a non-public route, the `authenticationRequiredHandler` is invoked. The default handler prevents the route/state from loading and transitions to the `login` route. Another handler can be installed like this:
+If the user is not signed in and accesses a non-public route, the route/state change is prevented and the `authenticationRequiredHandler` is invoked. The default handler transitions to the `login` route. Another handler can be installed like this:
 ```javascript
-user.onAuthenticationRequired(function(event, toState, toParams) {
+user.onAuthenticationRequired(function(toState, toParams) {
    // open login popup, do transition, ...
 });
 ```
-For the Angular router the ```routeChangeEvent``` and the target route are passed as parameters to the handler. For the UI router, the ```stateChangeEvent```, the target state and the target state parameters are passed.
+For the Angular router the target route is passed to the handler. For the UI router, the target state and the target state parameters are passed.
 
 
 To add required permissions to a route, use the `hasPermission` property and specify all the permissions as an array, like this:
@@ -268,15 +268,15 @@ If the UI router is used, the state parameters are passed as a second parameter:
 $stateProvider.state('admin', { data: { public: false, authCheck: function(user, params) { return user.properties['orgId'] === params.id } } });
 ```
 
-If access is denied to the logged in user (either because a required permission was not found or `authCheck` returned false), the `authorizationDeniedHandler` is invoked. The default handler redirects to the default route. Another handler can be installed like this:
+If access is denied to the logged in user (either because a required permission was not found or `authCheck` returned false), the route/state change is prevented and the `authorizationDeniedHandler` is invoked. The default handler redirects to the default route. Another handler can be installed like this:
 
 ```javascript
-user.onAccessDenied(function(user, event, state, params) {
+user.onAccessDenied(function(user, state, params) {
     // show popup, do transition, ...
 });
 ```
 
-For the Angular router the ```routeChangeEvent``` and the target route are passed as second and third parameters to the handler. For the UI router, the ```stateChangeEvent```, the target state, and the target state parameters are passed as parameters two, three, and four.
+For the Angular router the target route is passed as second parameter to the handler. For the UI router, the target state and the target state parameters are passed as parameters two and three.
 
 
 ## Loaders

--- a/angularjs.userapp.js
+++ b/angularjs.userapp.js
@@ -212,6 +212,10 @@ var userappModule = angular.module('UserApp', []);
                             if (!that.hasPermission(toState.data.hasPermission)) {
                                 accessDeniedHandler(that.current, ev, toState, toParams);
                             }
+                        } else if (toState.data && toState.data.authCheck) {
+                            if (!toState.data.authCheck(that.current, toParams)) {
+                                accessDeniedHandler(that.current, ev, toState, toParams);
+                            }
                         }
                     });
                 } else if ($route) {
@@ -227,6 +231,10 @@ var userappModule = angular.module('UserApp', []);
                             authenticationRequiredHandler(ev, data);
                         } else if (data.$$route && data.$$route.hasPermission && that.current.permissions) {
                             if (!that.hasPermission(data.$$route.hasPermission)) {
+                                accessDeniedHandler(that.current, ev, data);
+                            }
+                        } else if (data.$$route && data.$$route.authCheck) {
+                            if (!data.$$route.authCheck(that.current)) {
                                 accessDeniedHandler(that.current, ev, data);
                             }
                         }

--- a/angularjs.userapp.js
+++ b/angularjs.userapp.js
@@ -312,7 +312,6 @@ var userappModule = angular.module('UserApp', []);
                 this.loadUser(function(error, result) {
                     if (!error) {
                         callback && callback(error, result);
-                        $rootScope.$broadcast('user.login');
 
                         // reload the current route/state which triggers reevaluation of access rights
                         if ($state) {
@@ -320,7 +319,9 @@ var userappModule = angular.module('UserApp', []);
                         } else if ($route) {
                             $route.reload();
                         }
-                    } else {
+
+						$rootScope.$broadcast('user.login');
+					} else {
                         that.reset();
                     }
                 });

--- a/angularjs.userapp.js
+++ b/angularjs.userapp.js
@@ -266,19 +266,11 @@ var userappModule = angular.module('UserApp', []);
                     delete user[key];
                 }
 
-                // Redirect to login route
+                // reload the current route/state which triggers reevaluation of access rights
                 if ($state) {
-                    if ($state.$current && (!$state.$current.data || isPublic($state.$current.data) == false)) {
-                        $timeout(function() {
-                            transitionTo(loginRoute, true);
-                        });
-                    }
+                    $state.reload();
                 } else if ($route) {
-                    if ($route.current && isPublic($route.current.$$route) == false) {
-                        $timeout(function() {
-                            transitionTo(loginRoute);
-                        });
-                    }
+                    $route.reload();
                 }
             },
 
@@ -316,44 +308,17 @@ var userappModule = angular.module('UserApp', []);
                 this.token(token);
                 this.startHeartbeat(options.heartbeatInterval);
 
-                // Redirect to default route
-                if ($state) {
-                    if ($state.$current && $state.$current.data && isPublic($state.$current.data)) {
-                        $timeout(function() {
-                            transitionTo(defaultRoute, true);
-                        });
-                    }
-                } else if ($route) {
-                    if ($route.current && isPublic($route.current.$$route)) {
-                        $timeout(function() {
-                            transitionTo(defaultRoute);
-                        });
-                    }
-                }
-
                 // Load the logged in user
                 this.loadUser(function(error, result) {
                     if (!error) {
                         callback && callback(error, result);
                         $rootScope.$broadcast('user.login');
 
-                        // Check permissions for this route
+                        // reload the current route/state which triggers reevaluation of access rights
                         if ($state) {
-                            if ($state.$current && $state.$current.data && $state.$current.data.hasPermission) {
-                                if (!that.hasPermission($state.$current.data.hasPermission)) { 
-                                    $timeout(function() {
-                                        transitionTo(defaultRoute, true);
-                                    });
-                                }
-                            }
+                            $state.reload();
                         } else if ($route) {
-                            if ($route.current && $route.current.$$route.hasPermission) {
-                                if (!that.hasPermission($route.current.$$route.hasPermission)) { 
-                                    $timeout(function() {
-                                        transitionTo(defaultRoute);
-                                    });
-                                }
-                            }
+                            $route.reload();
                         }
                     } else {
                         that.reset();

--- a/angularjs.userapp.js
+++ b/angularjs.userapp.js
@@ -125,7 +125,9 @@ var userappModule = angular.module('UserApp', []);
                         stateChangeStartEvent.preventDefault();
                     accessDeniedHandler(user, state, stateParams);
                 }
-            } else if (state.data && state.data.authCheck && status.authenticated) {
+            }
+            // only do auth check if user is loaded (indicated by user_id present)
+            else if (state.data && state.data.authCheck && user.user_id) {
                 if (!state.data.authCheck(user, stateParams)) {
                     if(stateChangeStartEvent)
                         stateChangeStartEvent.preventDefault();

--- a/angularjs.userapp.js
+++ b/angularjs.userapp.js
@@ -119,13 +119,13 @@ var userappModule = angular.module('UserApp', []);
                 if(stateChangeStartEvent)
                     stateChangeStartEvent.preventDefault();
                 authenticationRequiredHandler(state, stateParams);
-            } else if ((state.data && state.data.hasPermission) && user.permissions) {
+            } else if (state.data && state.data.hasPermission && user.permissions) {
                 if (!service.hasPermission(state.data.hasPermission)) {
                     if(stateChangeStartEvent)
                         stateChangeStartEvent.preventDefault();
                     accessDeniedHandler(user, state, stateParams);
                 }
-            } else if (state.data && state.data.authCheck) {
+            } else if (state.data && state.data.authCheck && status.authenticated) {
                 if (!state.data.authCheck(user, stateParams)) {
                     if(stateChangeStartEvent)
                         stateChangeStartEvent.preventDefault();
@@ -143,17 +143,17 @@ var userappModule = angular.module('UserApp', []);
                 if(routeChangeStartEvent)
                     routeChangeStartEvent.preventDefault();
                 authenticationRequiredHandler(routeChangeStartEvent, routeData);
-            } else if (routeData.$$route && routeData.$$route.hasPermission && service.current.permissions) {
+            } else if (routeData.$$route && routeData.$$route.hasPermission && user.permissions) {
                 if (!service.hasPermission(routeData.$$route.hasPermission)) {
                     if(routeChangeStartEvent)
                         routeChangeStartEvent.preventDefault();
-                    accessDeniedHandler(service.current, routeChangeStartEvent, routeData);
+                    accessDeniedHandler(user, routeChangeStartEvent, routeData);
                 }
-            } else if (routeData.$$route && routeData.$$route.authCheck) {
-                if (!routeData.$$route.authCheck(service.current)) {
+            } else if (routeData.$$route && routeData.$$route.authCheck && status.authenticated) {
+                if (!routeData.$$route.authCheck(user)) {
                     if(routeChangeStartEvent)
                         routeChangeStartEvent.preventDefault();
-                    accessDeniedHandler(service.current, routeChangeStartEvent, routeData);
+                    accessDeniedHandler(user, routeChangeStartEvent, routeData);
                 }
             }
         };


### PR DESCRIPTION
By introducing an `authorizationRequiredHandler` and an `accessDeniedHandler`, reaction to these two types of access control violations is more flexible.
`authCheck` complements `hasPermission` by a more flexible mechanism for access-checking of routes/states.
I cleaned up some other route/state transitions when logging in/out.

As a result, the login form could now be displayed in a popup (no dedicated login state required anymore), as well as a notification about access denial.
Logging in and out does not necessarily change the route/state anymore (if access rights allow that) but just reload the current state.

What do you think?
