### PR TITLE
authResolver doesn't resolve for public routes

### DIFF
--- a/angularjs.userapp.js
+++ b/angularjs.userapp.js
@@ -220,7 +220,7 @@ var userappModule = angular.module('UserApp', []);
                             var state = states[this.self.name];
                         }
                         
-                        if (isPublic($route ? $route.current.$$route : state) == false) {
+                        if (isPublic($route ? $route.current.$$route : state.data) == false) {
                             var deferred = $q.defer();
 
                             try {


### PR DESCRIPTION
Wrong object being passed into isPublic. This is causing isPublic to return false for public routes. When you are not logged in this means the current user promise never resolves and the state's resolve object never fully resolve.
